### PR TITLE
[Feat] 이미지 업로드 및 AI서버 호출 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//S3
+	implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.1.1")
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/graduate/req_server/config/aws/AwsConfig.java
+++ b/src/main/java/graduate/req_server/config/aws/AwsConfig.java
@@ -1,0 +1,51 @@
+package graduate.req_server.config.aws;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class AwsConfig {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${spring.cloud.aws.s3.region}")
+    private String region;
+
+    @Bean
+    public AwsCredentialsProvider customAwsCredentialsProvider() {
+        return () -> new AwsCredentials() {
+            @Override
+            public String accessKeyId() {
+                return accessKey;
+            }
+            @Override
+            public String secretAccessKey() {
+                return secretKey;
+            }
+        };
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .credentialsProvider(customAwsCredentialsProvider())
+                .region(Region.of(region))
+                .build();
+    }
+
+    @Bean
+    public S3AsyncClient s3AsyncClient() {
+        return S3AsyncClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(customAwsCredentialsProvider())
+                .build();
+    }
+}

--- a/src/main/java/graduate/req_server/domain/image/controller/ImageController.java
+++ b/src/main/java/graduate/req_server/domain/image/controller/ImageController.java
@@ -1,0 +1,26 @@
+package graduate.req_server.domain.image.controller;
+
+import graduate.req_server.domain.image.dto.request.ImageRequest;
+import graduate.req_server.domain.image.dto.response.ImageResponse;
+import graduate.req_server.domain.image.service.ImageService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping
+    public ResponseEntity<ImageResponse> uploadImage(@ModelAttribute ImageRequest request) {
+        ImageResponse responses = imageService.uploadAndProcess(request);
+        return ResponseEntity.ok(responses);
+    }
+}

--- a/src/main/java/graduate/req_server/domain/image/dto/request/ImageRequest.java
+++ b/src/main/java/graduate/req_server/domain/image/dto/request/ImageRequest.java
@@ -1,0 +1,10 @@
+package graduate.req_server.domain.image.dto.request;
+
+import java.util.List;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+public class ImageRequest {
+    private List<MultipartFile> files;
+}

--- a/src/main/java/graduate/req_server/domain/image/dto/response/ImageResponse.java
+++ b/src/main/java/graduate/req_server/domain/image/dto/response/ImageResponse.java
@@ -1,0 +1,10 @@
+package graduate.req_server.domain.image.dto.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class ImageResponse {
+    private List<String> imageIds;
+    private String status;
+}

--- a/src/main/java/graduate/req_server/domain/image/service/ImageService.java
+++ b/src/main/java/graduate/req_server/domain/image/service/ImageService.java
@@ -1,0 +1,57 @@
+package graduate.req_server.domain.image.service;
+
+import graduate.req_server.domain.image.dto.request.ImageRequest;
+import graduate.req_server.domain.image.dto.response.ImageResponse;
+import graduate.req_server.util.ai.AiService;
+import graduate.req_server.util.file.MultipartUtils;
+import jakarta.transaction.Transactional;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final S3Client s3Client;
+    private final AiService aiService;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Transactional
+    public ImageResponse uploadAndProcess(ImageRequest request) {
+        List<MultipartFile> files = request.getFiles();
+        MultipartUtils.validateFiles(files);
+
+        List<String> ids = files.stream().map(file -> {
+            String ext = MultipartUtils.getExtension(file.getOriginalFilename());
+            String id = java.util.UUID.randomUUID().toString();
+            String key = "images/" + id + ext;
+            try (InputStream is = file.getInputStream()) {
+                s3Client.putObject(
+                        PutObjectRequest.builder()
+                                .bucket(bucket)
+                                .key(key)
+                                .build(),
+                        RequestBody.fromInputStream(is, file.getSize())
+                );
+            } catch (IOException e) {
+                //TODO Error
+            }
+            return id;
+        }).collect(Collectors.toList());
+
+        // AI 처리
+        String status = aiService.process(ids);
+        return new ImageResponse(ids, status);
+    }
+}

--- a/src/main/java/graduate/req_server/util/ai/AiService.java
+++ b/src/main/java/graduate/req_server/util/ai/AiService.java
@@ -1,0 +1,26 @@
+package graduate.req_server.util.ai;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+public class AiService {
+
+    @Value("${ai.server-url}")
+    private String aiUrl;
+    private final WebClient client;
+
+    public AiService() {
+        this.client = WebClient.builder().baseUrl(aiUrl).build();
+    }
+
+    public String process(List<String> imageIds) {
+        return client.post()
+                .bodyValue(imageIds)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+}

--- a/src/main/java/graduate/req_server/util/file/MultipartUtils.java
+++ b/src/main/java/graduate/req_server/util/file/MultipartUtils.java
@@ -1,0 +1,20 @@
+package graduate.req_server.util.file;
+
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public class MultipartUtils {
+
+    public static void validateFiles(List<MultipartFile> files) {
+        if (files == null || files.isEmpty()) {
+            //TODO Error
+        }
+    }
+
+    public static String getExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            return "";
+        }
+        return filename.substring(filename.lastIndexOf('.'));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,6 @@ spring:
         region: ${BUCKET_REGION}
         bucket: ${BUCKET_NAME}
 
+# AI
+ai:
+  server-url: ${AI_SERVER_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,18 @@
 spring:
   application:
     name: req-server
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DATASOURCE_URL}
+    username: ${DATASOURCE_USERNAME}
+    password: ${DATASOURCE_PASSWORD}
+# S3
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_ACCESS_KEY}
+        secret-key: ${AWS_SECRET_KEY}
+      s3:
+        region: ${BUCKET_REGION}
+        bucket: ${BUCKET_NAME}
+


### PR DESCRIPTION
## 📎 Issue 번호
- #1 

## 📄 상세 작업 내용
- 초기 프로젝트 설정
- S3 동기 클라이언트 사용
- Multipart 파일 검증, 확장자 추출 유틸리티 구현
- WebClient를 사용해 AI서버 동기 호출 로직 작성
- 스트림 방식으로 이미지 업로드 구현

## 🤔 고민한 부분
- 스트림 업로드 vs 디스크에 임시 파일 작성
    - 선택 : 스트림 업로드
    - 이유 :
        - 디스크 I/O 오버헤드를 제거해 용량이 작은 다수의 파일 처리 시 속도 저하 방지
        - JVM에서 Heap Memory 대신 Network Buffer만 사용하여 메모리 사용량 예측
        - 초기의 전송 안정성은 S3의 자동 재시도 기능으로 보완 가능
- DTO 바인딩 방식 ModelAttribute vs RequestPart
    - 선택 : ModelAttribute
    - 이유 : 
        - 메타데이터 필드 추가 시 확장 용이(업로더 정보 등)
        - 요청 전체를 하나의 객체로 관리
- 동기 vs 비동기
    - 선택 : 동기 처리
    - 이유 : 
        - MVP에서 간단한 흐름으로 빠르게 검증하기 위함
        - 에러 발생 시 호출 스택이 명확해 디버깅 용이
        - (추후 비동기 전환 예정)

## ☑️ TO DO
- 비동기 처리
- 예외 처리
- 클라이언트 응답 통일화
