### PR TITLE
[Feat] 조회 요청에 대한 응답 데이터 필드 추가 & 점수에 따른 필터링 적용 

### DIFF
--- a/src/main/java/graduate/req_server/config/aws/s3/AwsConfig.java
+++ b/src/main/java/graduate/req_server/config/aws/s3/AwsConfig.java
@@ -1,4 +1,4 @@
-package graduate.req_server.config.aws;
+package graduate.req_server.config.aws.s3;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -8,6 +8,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Utilities;
 
 @Configuration
 public class AwsConfig {
@@ -47,5 +48,10 @@ public class AwsConfig {
                 .region(Region.of(region))
                 .credentialsProvider(customAwsCredentialsProvider())
                 .build();
+    }
+
+    @Bean
+    public S3Utilities s3Utilities(S3Client s3Client) {
+        return s3Client.utilities();
     }
 }

--- a/src/main/java/graduate/req_server/config/aws/s3/S3Properties.java
+++ b/src/main/java/graduate/req_server/config/aws/s3/S3Properties.java
@@ -1,0 +1,15 @@
+package graduate.req_server.config.aws.s3;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class S3Properties {
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucket;
+    @Value("${spring.cloud.aws.s3.region}")
+    private String region;
+}

--- a/src/main/java/graduate/req_server/domain/image/controller/ImageController.java
+++ b/src/main/java/graduate/req_server/domain/image/controller/ImageController.java
@@ -1,10 +1,10 @@
 package graduate.req_server.domain.image.controller;
 
 import graduate.req_server.domain.image.dto.request.ImageRequest;
-import graduate.req_server.domain.image.dto.response.ImageResponse;
 import graduate.req_server.domain.image.service.ImageService;
 import graduate.req_server.util.client.ai.dto.UploadResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,12 +14,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/images")
 @RequiredArgsConstructor
+@Slf4j
 public class ImageController {
 
     private final ImageService imageService;
 
     @PostMapping
     public ResponseEntity<UploadResponse> uploadImage(@ModelAttribute ImageRequest request) {
+        log.debug("[ImageController] uploadImage");
+
         UploadResponse responses = imageService.uploadAndProcess(request);
         return ResponseEntity.ok(responses);
     }

--- a/src/main/java/graduate/req_server/domain/image/service/ImageService.java
+++ b/src/main/java/graduate/req_server/domain/image/service/ImageService.java
@@ -1,7 +1,6 @@
 package graduate.req_server.domain.image.service;
 
 import graduate.req_server.domain.image.dto.request.ImageRequest;
-import graduate.req_server.domain.image.dto.response.ImageResponse;
 import graduate.req_server.util.client.ai.AiClient;
 import graduate.req_server.util.client.ai.dto.UploadResponse;
 import graduate.req_server.util.file.MultipartUtils;
@@ -10,6 +9,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,6 +17,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ImageService {
@@ -28,6 +29,8 @@ public class ImageService {
     private String bucket;
 
     public UploadResponse uploadAndProcess(ImageRequest request) {
+        log.debug("[ImageService] uploadAndProcess");
+
         List<MultipartFile> files = request.getFiles();
         MultipartUtils.validateFiles(files);
 

--- a/src/main/java/graduate/req_server/domain/search/controller/SearchController.java
+++ b/src/main/java/graduate/req_server/domain/search/controller/SearchController.java
@@ -4,6 +4,7 @@ import graduate.req_server.domain.search.dto.request.SearchRequest;
 import graduate.req_server.domain.search.dto.response.SearchResponse;
 import graduate.req_server.domain.search.service.SearchService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,12 +14,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/search")
 @RequiredArgsConstructor
+@Slf4j
 public class SearchController {
 
     private final SearchService searchService;
 
     @GetMapping
     public ResponseEntity<SearchResponse> search(@RequestParam String query) {
+        log.debug("[SearchController] search");
+
         return ResponseEntity.ok(searchService.searchByText(new SearchRequest(query)));
     }
 }

--- a/src/main/java/graduate/req_server/domain/search/controller/StatusController.java
+++ b/src/main/java/graduate/req_server/domain/search/controller/StatusController.java
@@ -3,11 +3,13 @@ package graduate.req_server.domain.search.controller;
 import graduate.req_server.domain.search.dto.response.StatusResponse;
 import graduate.req_server.domain.search.service.StatusService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/status")
 @RequiredArgsConstructor
@@ -17,6 +19,7 @@ public class StatusController {
 
     @GetMapping
     public ResponseEntity<StatusResponse> search() {
+        log.debug("[StatusController] search");
         return ResponseEntity.ok(statusService.getStats("images"));
     }
 }

--- a/src/main/java/graduate/req_server/domain/search/dto/response/PhotoInfo.java
+++ b/src/main/java/graduate/req_server/domain/search/dto/response/PhotoInfo.java
@@ -1,12 +1,13 @@
 package graduate.req_server.domain.search.dto.response;
 
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
-public class SearchResponse {
+public class PhotoInfo {
 
-    private List<PhotoInfo> photos;
+    private String url;
+    private double size;
+    private double score;
 }

--- a/src/main/java/graduate/req_server/domain/search/service/SearchService.java
+++ b/src/main/java/graduate/req_server/domain/search/service/SearchService.java
@@ -10,11 +10,7 @@ import io.pinecone.unsigned_indices_model.ScoredVectorWithUnsignedIndices;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
-import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
 @Slf4j
 @Service

--- a/src/main/java/graduate/req_server/domain/search/service/SearchService.java
+++ b/src/main/java/graduate/req_server/domain/search/service/SearchService.java
@@ -1,21 +1,28 @@
 package graduate.req_server.domain.search.service;
 
 import graduate.req_server.domain.search.dto.request.SearchRequest;
+import graduate.req_server.domain.search.dto.response.PhotoInfo;
 import graduate.req_server.domain.search.dto.response.SearchResponse;
 import graduate.req_server.util.client.ai.AiClient;
 import graduate.req_server.util.client.PineconeClient;
+import io.pinecone.unsigned_indices_model.ScoredVectorWithUnsignedIndices;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SearchService {
 
     private final AiClient aiClient;
     private final PineconeClient pineconeClient;
+    private final S3Client s3Client;
 
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
@@ -23,14 +30,40 @@ public class SearchService {
     @Value("${spring.cloud.aws.s3.region}")
     private String region;
 
-    private final String prefix ="images";
-
     public SearchResponse searchByText(SearchRequest request) {
+        log.info("[SearchService] searchByText");
+
+        double minScore = 0.12;
+
         List<Float> vector = aiClient.textToVector(request.getQuery());
-        List<String> keys = pineconeClient.queryTopK(vector);
-        List<String> urls = keys.stream()
-                .map(key -> String.format("https://%s.s3.%s.amazonaws.com/%s/%s", bucket, region,prefix, key))
-                .collect(Collectors.toList());
-        return new SearchResponse(urls);
+        List<ScoredVectorWithUnsignedIndices> matches = pineconeClient.queryTopKWithScore(vector);
+
+        List<PhotoInfo> photos = matches.stream()
+                .filter(m -> m.getScore() >= minScore)
+                .map(m -> {
+                    String id = m.getId();
+                    double score = m.getScore();
+
+                    String key = "images/" + id;
+                    String url = String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region,
+                            key);
+
+                    double size;
+                    try {
+                        size = s3Client.headObject(
+                                HeadObjectRequest.builder()
+                                        .bucket(bucket).key(key)
+                                        .build()
+                        ).contentLength();
+                    } catch (NoSuchKeyException e) {
+                        size = 0L;
+                    }
+                    size /= (1024.0 * 1024.0);
+                    size = Math.round(size * 10) / 10.0;
+
+                    return new PhotoInfo(url, size, score);
+                }).toList();
+
+        return new SearchResponse(photos);
     }
 }

--- a/src/main/java/graduate/req_server/domain/search/service/StatusService.java
+++ b/src/main/java/graduate/req_server/domain/search/service/StatusService.java
@@ -20,13 +20,11 @@ public class StatusService {
 
     @Value("${spring.cloud.aws.s3.bucket}")
     private String bucket;
-
-    @Value("${spring.cloud.aws.s3.region}")
-    private String region;
     private final S3Client s3Client;
 
 
     public StatusResponse getStats(String prefix) {
+        log.debug("[StatusService] getStats");
         long totalSize = 0L;
         int fileCount = 0;
         String continuationToken = null;

--- a/src/main/java/graduate/req_server/util/client/PineconeClient.java
+++ b/src/main/java/graduate/req_server/util/client/PineconeClient.java
@@ -5,7 +5,7 @@ import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;
 import io.pinecone.unsigned_indices_model.ScoredVectorWithUnsignedIndices;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -28,12 +28,9 @@ public class PineconeClient {
                 topK,
                 vector
         );
-        if(response==null || response.getMatchesList().isEmpty()) {
-            return Collections.emptyList();
-        }
 
-        return response.getMatchesList().stream()
-                .map(ScoredVectorWithUnsignedIndices::getId)
-                .collect(Collectors.toList());
+        return Optional.ofNullable(response)
+                .map(QueryResponseWithUnsignedIndices::getMatchesList)
+                .orElse(Collections.emptyList());
     }
 }

--- a/src/main/java/graduate/req_server/util/client/PineconeClient.java
+++ b/src/main/java/graduate/req_server/util/client/PineconeClient.java
@@ -7,9 +7,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PineconeClient {
@@ -19,7 +21,8 @@ public class PineconeClient {
     @Value("${pinecone.top-k}")
     private int topK;
 
-    public List<String> queryTopK(List<Float> vector) {
+    public List<ScoredVectorWithUnsignedIndices> queryTopKWithScore(List<Float> vector) {
+        log.debug("[PineconeClient] queryTopKWithScore");
 
         QueryResponseWithUnsignedIndices response = pineconeIndex.queryByVector(
                 topK,

--- a/src/main/java/graduate/req_server/util/client/ai/AiClient.java
+++ b/src/main/java/graduate/req_server/util/client/ai/AiClient.java
@@ -4,10 +4,12 @@ import graduate.req_server.util.client.ai.dto.UploadResponse;
 import graduate.req_server.util.client.ai.dto.VectorResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AiClient {
@@ -19,6 +21,8 @@ public class AiClient {
     private String textToVectorPath;
 
     public UploadResponse vectorizeAndStore(List<String> imageIds) {
+        log.debug("[AiClient] vectorizeAndStore");
+
         return aiWebClient.post()
                 .uri(imageToVectorPath)
                 .bodyValue(imageIds)
@@ -28,6 +32,8 @@ public class AiClient {
     }
 
     public List<Float> textToVector(String text) {
+        log.debug("[AiClient] textToVector");
+
         VectorResponse response = aiWebClient.get()
                 .uri(uriBuilder ->
                         uriBuilder

--- a/src/main/java/graduate/req_server/util/client/pinecone/PineconeClient.java
+++ b/src/main/java/graduate/req_server/util/client/pinecone/PineconeClient.java
@@ -1,4 +1,4 @@
-package graduate.req_server.util.client;
+package graduate.req_server.util.client.pinecone;
 
 import io.pinecone.clients.Index;
 import io.pinecone.unsigned_indices_model.QueryResponseWithUnsignedIndices;

--- a/src/main/java/graduate/req_server/util/client/s3/S3Service.java
+++ b/src/main/java/graduate/req_server/util/client/s3/S3Service.java
@@ -1,0 +1,70 @@
+package graduate.req_server.util.client.s3;
+
+import graduate.req_server.config.aws.s3.S3Properties;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Utilities;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+    private final S3Properties properties;
+    private final S3Utilities s3Utilities;
+
+    public String uploadFile(MultipartFile file) {
+        String key = String.valueOf(UUID.randomUUID());
+        try (InputStream is = file.getInputStream()) {
+            s3Client.putObject(
+                    PutObjectRequest.builder()
+                            .bucket(properties.getBucket())
+                            .key(key)
+                            .build(),
+                    RequestBody.fromInputStream(is, file.getSize())
+            );
+        } catch (IOException e) {
+            //TODO Error
+        }
+        return key;
+    }
+
+    public String getFileUrl(String key) {
+        return s3Utilities.getUrl(
+                GetUrlRequest.builder()
+                        .bucket(properties.getBucket())
+                        .key(key)
+                        .build()
+        ).toExternalForm();
+    }
+
+    public double getFileSize(String key) {
+        long bytes;
+        try {
+            bytes = s3Client.headObject(HeadObjectRequest.builder()
+                            .bucket(properties.getBucket())
+                            .key(key)
+                            .build())
+                    .contentLength();
+        } catch (NoSuchKeyException e) {
+            bytes = 0L;
+        }
+
+        return bytesToMB(bytes);
+    }
+
+    private double bytesToMB(long bytes) {
+        double mb = bytes / (1024.0 * 1024.0);
+        return Math.round(mb * 10) / 10.0;
+    }
+}


### PR DESCRIPTION
## 📎 Issue 번호
- #18 

## 📄 상세 작업 내용
- 사진 조회 시 응답 데이터에 사진 크기(MB 단위)와 벡터 점수 포함
- 벡터 점수에 대한 필터링 적용
- S3 관련 로직 분리

## ☑️ TO DO
- 테스트
- 예외처리
